### PR TITLE
Merging Modular Events System

### DIFF
--- a/Assets/Scripts/NpcEvents.meta
+++ b/Assets/Scripts/NpcEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9eb5c5eec3235248997420256cb63f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/NpcEvent.cs
+++ b/Assets/Scripts/NpcEvents/NpcEvent.cs
@@ -1,0 +1,44 @@
+/******************************************************************
+*    Author: Nick Grinstead
+*    Contributors: 
+*    Date Created: 5/16/24
+*    Description: A template event script to create ScriptableObject events
+*       from. Tracks listeners and updates them when the event triggers.
+*    Reference/Source: https://youtu.be/J01z1F-du-E?t=635 (10:32 - 12:45)
+*******************************************************************/
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "NPC Event")]
+public class NpcEvent : ScriptableObject
+{
+    private List<NpcEventListener> _eventListeners = new List<NpcEventListener>();
+
+    /// <summary>
+    /// Called from another script to trigger this event.
+    /// </summary>
+    public void TriggerEvent()
+    {
+        for (int i = 0; i < _eventListeners.Count; ++i)
+        {
+            _eventListeners[i].OnEventTriggered();
+        }
+    }
+
+    /// <summary>
+    /// Allows NpcEventListeners to register themselves.
+    /// </summary>
+    public void AddListener(NpcEventListener newListener)
+    {
+        _eventListeners.Add(newListener);
+    }
+
+    /// <summary>
+    /// Allows NpcEventListeners to unregister themselves
+    /// </summary>
+    public void RemoveListener(NpcEventListener listenerToRemove)
+    {
+        _eventListeners.Remove(listenerToRemove);
+    }
+}

--- a/Assets/Scripts/NpcEvents/NpcEvent.cs
+++ b/Assets/Scripts/NpcEvents/NpcEvent.cs
@@ -16,13 +16,14 @@ public class NpcEvent : ScriptableObject
     private List<NpcEventListener> _eventListeners = new List<NpcEventListener>();
 
     /// <summary>
-    /// Called from another script to trigger this event.
+    /// Called from another script to trigger this event. Event tags serve to 
+    /// distinguish events related to different NPCs, quests, items, etc.
     /// </summary>
-    public void TriggerEvent()
+    public void TriggerEvent(string eventTag)
     {
         for (int i = 0; i < _eventListeners.Count; ++i)
         {
-            _eventListeners[i].OnEventTriggered();
+            _eventListeners[i].OnEventTriggered(eventTag);
         }
     }
 

--- a/Assets/Scripts/NpcEvents/NpcEvent.cs.meta
+++ b/Assets/Scripts/NpcEvents/NpcEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cccd1b3ed5799b449d60399408c05bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/NpcEventListener.cs
+++ b/Assets/Scripts/NpcEvents/NpcEventListener.cs
@@ -15,14 +15,19 @@ using UnityEngine.Events;
 public class NpcEventListener : MonoBehaviour
 {
     [SerializeField] private NpcEvent npcEvent;
+    [SerializeField] private string targetEventTag;
     [SerializeField] private UnityEvent onEventTriggered;
 
     /// <summary>
-    /// Called by NpcEvent to invoke a local UnityEvent.
+    /// Called by NpcEvent to invoke a local UnityEvent if the incoming event tag
+    /// matches to target.
     /// </summary>
-    public void OnEventTriggered()
+    public void OnEventTriggered(string eventTag)
     {
-        onEventTriggered.Invoke();
+        if (eventTag.Equals(targetEventTag))
+        {
+            onEventTriggered.Invoke();
+        }
     }
 
     private void OnEnable()

--- a/Assets/Scripts/NpcEvents/NpcEventListener.cs
+++ b/Assets/Scripts/NpcEvents/NpcEventListener.cs
@@ -14,9 +14,9 @@ using UnityEngine.Events;
 
 public class NpcEventListener : MonoBehaviour
 {
-    [SerializeField] private NpcEvent npcEvent;
-    [SerializeField] private string targetEventTag;
-    [SerializeField] private UnityEvent onEventTriggered;
+    [SerializeField] private NpcEvent _npcEvent;
+    [SerializeField] private string _targetEventTag;
+    [SerializeField] private UnityEvent _onEventTriggered;
 
     /// <summary>
     /// Called by NpcEvent to invoke a local UnityEvent if the incoming event tag
@@ -24,19 +24,19 @@ public class NpcEventListener : MonoBehaviour
     /// </summary>
     public void OnEventTriggered(string eventTag)
     {
-        if (eventTag.Equals(targetEventTag))
+        if (eventTag.Equals(_targetEventTag))
         {
-            onEventTriggered.Invoke();
+            _onEventTriggered.Invoke();
         }
     }
 
     private void OnEnable()
     {
-        npcEvent.AddListener(this);
+        _npcEvent.AddListener(this);
     }
 
     private void OnDisable()
     {
-        npcEvent.RemoveListener(this);
+        _npcEvent.RemoveListener(this);
     }
 }

--- a/Assets/Scripts/NpcEvents/NpcEventListener.cs
+++ b/Assets/Scripts/NpcEvents/NpcEventListener.cs
@@ -1,0 +1,37 @@
+/******************************************************************
+*    Author: Nick Grinstead
+*    Contributors: 
+*    Date Created: 5/16/24
+*    Description: Add this script to any object that needs to listen
+*       for certain events to occur. Will invoke methods on various
+*       components when event is recieved.
+*    Reference/Source: https://youtu.be/J01z1F-du-E?t=635 (10:32 - 12:45)
+*******************************************************************/
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class NpcEventListener : MonoBehaviour
+{
+    [SerializeField] private NpcEvent npcEvent;
+    [SerializeField] private UnityEvent onEventTriggered;
+
+    /// <summary>
+    /// Called by NpcEvent to invoke a local UnityEvent.
+    /// </summary>
+    public void OnEventTriggered()
+    {
+        onEventTriggered.Invoke();
+    }
+
+    private void OnEnable()
+    {
+        npcEvent.AddListener(this);
+    }
+
+    private void OnDisable()
+    {
+        npcEvent.RemoveListener(this);
+    }
+}

--- a/Assets/Scripts/NpcEvents/NpcEventListener.cs.meta
+++ b/Assets/Scripts/NpcEvents/NpcEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a0acc881a336094997b0fb61c6d1983
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/OnItemCollected.asset
+++ b/Assets/Scripts/NpcEvents/OnItemCollected.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cccd1b3ed5799b449d60399408c05bd, type: 3}
+  m_Name: OnItemCollected
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/NpcEvents/OnItemCollected.asset.meta
+++ b/Assets/Scripts/NpcEvents/OnItemCollected.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0ff38f0f20db8a4ab04033934de185c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/OnQuestCompleted.asset
+++ b/Assets/Scripts/NpcEvents/OnQuestCompleted.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cccd1b3ed5799b449d60399408c05bd, type: 3}
+  m_Name: OnQuestCompleted
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/NpcEvents/OnQuestCompleted.asset.meta
+++ b/Assets/Scripts/NpcEvents/OnQuestCompleted.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b7b5ccfabcfc4d4f96da8928978e41e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/OnQuestFailed.asset
+++ b/Assets/Scripts/NpcEvents/OnQuestFailed.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cccd1b3ed5799b449d60399408c05bd, type: 3}
+  m_Name: OnQuestFailed
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/NpcEvents/OnQuestFailed.asset.meta
+++ b/Assets/Scripts/NpcEvents/OnQuestFailed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b378c7bf95cf604c879b63ee58613f0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
NpcEvent allows for creating ScriptableObject events that can be heard by an NpcEventListener script or triggered by any script.
This will allow for systems like quests, NPCs, and menus to talk to each other more easily.