### PR TITLE
cleans up event system

### DIFF
--- a/Assets/Prefabs/Map/MapTriggers.prefab
+++ b/Assets/Prefabs/Map/MapTriggers.prefab
@@ -67,6 +67,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _onEnterRoom: {fileID: 11400000, guid: 9f71d044c4d09304588beadc31eb08d4, type: 2}
+  _eventTag: 5
 --- !u!1 &5266479173306512446
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCs/Coward.prefab
+++ b/Assets/Prefabs/NPCs/Coward.prefab
@@ -375,7 +375,7 @@ MonoBehaviour:
             m_BoolArgument: 0
           m_CallState: 2
   - _npcEvent: {fileID: 11400000, guid: 9f71d044c4d09304588beadc31eb08d4, type: 2}
-    _npcEventTag: 9
+    _npcEventTag: 5
     _onEventTriggered:
       m_PersistentCalls:
         m_Calls:

--- a/Assets/Prefabs/NPCs/Goop.prefab
+++ b/Assets/Prefabs/NPCs/Goop.prefab
@@ -147,6 +147,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _npcName: Goop
   _targetBypassItem: {fileID: 0}
+  _onEnterFailState: {fileID: 0}
   _startMinigameEvent: {fileID: 0}
   _eventTag: 5
   _stateDialogueTrees:
@@ -291,7 +292,7 @@ MonoBehaviour:
         opened the door to the bridge for you."
       _playerResponses:
       - _eventToTrigger: {fileID: 11400000, guid: 0dc09a2e909bfa14ba070b27da962183, type: 2}
-        _eventTag: 5
+        _eventTag: 4
         _hasPrerequisiteCheck: 0
         _answer: <b>Leave
         _nextResponseIndex: 
@@ -313,7 +314,7 @@ MonoBehaviour:
         hurt."
       _playerResponses:
       - _eventToTrigger: {fileID: 11400000, guid: 0dc09a2e909bfa14ba070b27da962183, type: 2}
-        _eventTag: 5
+        _eventTag: 4
         _hasPrerequisiteCheck: 0
         _answer: <b>Leave
         _nextResponseIndex: 
@@ -369,7 +370,7 @@ MonoBehaviour:
         hurt."
       _playerResponses:
       - _eventToTrigger: {fileID: 11400000, guid: 0dc09a2e909bfa14ba070b27da962183, type: 2}
-        _eventTag: 5
+        _eventTag: 4
         _hasPrerequisiteCheck: 0
         _answer: <b>Leave
         _nextResponseIndex: 
@@ -387,7 +388,7 @@ MonoBehaviour:
         _advancesNpcState: 0
         _endsDialogue: 0
       - _eventToTrigger: {fileID: 11400000, guid: 8b7b5ccfabcfc4d4f96da8928978e41e, type: 2}
-        _eventTag: 5
+        _eventTag: 0
         _hasPrerequisiteCheck: 0
         _answer: The captain is injured
         _nextResponseIndex: 02000000
@@ -462,11 +463,11 @@ MonoBehaviour:
             m_BoolArgument: 0
           m_CallState: 2
   - _npcEvent: {fileID: 11400000, guid: 8b7b5ccfabcfc4d4f96da8928978e41e, type: 2}
-    _npcEventTag: 5
+    _npcEventTag: 0
     _onEventTriggered:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 135958869701333940, guid: 9e2d2e42467cdaa469595eb50e8393e1, type: 3}
+        - m_Target: {fileID: 0}
           m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
           m_MethodName: SetActive
           m_Mode: 6

--- a/Assets/Prefabs/NPCs/Robot.prefab
+++ b/Assets/Prefabs/NPCs/Robot.prefab
@@ -147,6 +147,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _npcName: Robot
   _targetBypassItem: {fileID: 11400000, guid: ce9c4a38351e1ac41b75157f79779d20, type: 2}
+  _onEnterFailState: {fileID: 11400000, guid: 820e77e5460d5cd4cb472f8466ef6e1c, type: 2}
   _startMinigameEvent: {fileID: 11400000, guid: dd6c7f105503f694baf744be912b1974, type: 2}
   _eventTag: 6
   _stateDialogueTrees:

--- a/Assets/Scenes/Level/GreyBoxing.unity
+++ b/Assets/Scenes/Level/GreyBoxing.unity
@@ -16675,7 +16675,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _eventsToListenFor:
   - _npcEvent: {fileID: 11400000, guid: 8b7b5ccfabcfc4d4f96da8928978e41e, type: 2}
-    _npcEventTag: 6
+    _npcEventTag: 5
     _onEventTriggered:
       m_PersistentCalls:
         m_Calls:
@@ -41913,7 +41913,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _eventsToListenFor:
   - _npcEvent: {fileID: 11400000, guid: 0dc09a2e909bfa14ba070b27da962183, type: 2}
-    _npcEventTag: 5
+    _npcEventTag: 4
     _onEventTriggered:
       m_PersistentCalls:
         m_Calls:
@@ -47042,6 +47042,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1869879217}
     m_Modifications:
+    - target: {fileID: 869825619415053396, guid: f188daf20aada014c9268d86af53b853, type: 3}
+      propertyPath: _stateDialogueTrees._postMinigameState.Array.data[0]._playerResponses.Array.data[0]._eventTag
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 4556153407337933796, guid: f188daf20aada014c9268d86af53b853, type: 3}
       propertyPath: m_Name
       value: Robot
@@ -48375,7 +48379,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _eventsToListenFor:
   - _npcEvent: {fileID: 11400000, guid: 0dc09a2e909bfa14ba070b27da962183, type: 2}
-    _npcEventTag: 6
+    _npcEventTag: 5
     _onEventTriggered:
       m_PersistentCalls:
         m_Calls:

--- a/Assets/Scripts/NpcEvents/NpcEvent.cs
+++ b/Assets/Scripts/NpcEvents/NpcEvent.cs
@@ -19,12 +19,8 @@ public enum NpcEventTags
     Coward,
     Fish,
     Game,
-    Gladiator,
-    Gnomes,
     Goop,
     Robot,
-    Lightbulb, // TODO: remove this tag once NPCs are tied into inventory system
-    Lab // TODO: possibly remove this once an on-enter room system is created
 }
 
 [CreateAssetMenu(menuName = "NPC Event")]

--- a/Assets/Scripts/NpcEvents/NpcEvent.cs
+++ b/Assets/Scripts/NpcEvents/NpcEvent.cs
@@ -21,6 +21,10 @@ public enum NpcEventTags
     Game,
     Goop,
     Robot,
+
+    GeneratorDeath,
+    FireDeath,
+    ShipDeath
 }
 
 [CreateAssetMenu(menuName = "NPC Event")]

--- a/Assets/Scripts/NpcEvents/On30SecondsLeft.asset
+++ b/Assets/Scripts/NpcEvents/On30SecondsLeft.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cccd1b3ed5799b449d60399408c05bd, type: 3}
+  m_Name: On30SecondsLeft
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/NpcEvents/On30SecondsLeft.asset.meta
+++ b/Assets/Scripts/NpcEvents/On30SecondsLeft.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 718aa8d808aa79a40abc3266d2f16f80
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/OnDeath.asset
+++ b/Assets/Scripts/NpcEvents/OnDeath.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5cccd1b3ed5799b449d60399408c05bd, type: 3}
+  m_Name: OnDeath
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/NpcEvents/OnDeath.asset.meta
+++ b/Assets/Scripts/NpcEvents/OnDeath.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ecd2838e2ea86b42a087aad7f6a97a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NpcEvents/RoomTriggers/OnEnterRoom.cs
+++ b/Assets/Scripts/NpcEvents/RoomTriggers/OnEnterRoom.cs
@@ -1,7 +1,7 @@
 /*****************************************************************************
 // File Name :         OnEnterRoom.cs
 // Author :            Andrea Swihart-DeCoster
-// Contributors :
+// Contributors :      Marissa Moser
 // Creation Date :     06/10/24
 //
 // Brief Description : Sends out events when the player enters a room.
@@ -14,12 +14,13 @@ using UnityEngine;
 public class OnEnterRoom : MonoBehaviour
 {
     [SerializeField] private NpcEvent _onEnterRoom;
+    [SerializeField] private NpcEventTags _eventTag;
 
     private void OnTriggerEnter(Collider other)
     {
         if(other.TryGetComponent<PlayerController>(out PlayerController playerController))
         {
-            _onEnterRoom.TriggerEvent(NpcEventTags.Lab);
+            _onEnterRoom.TriggerEvent(_eventTag);
         }
     }
 }


### PR DESCRIPTION
Depreciated old NPC tags: Got rid of gnome and gladiator tags, as well as the lightbulb and lab tag. The latter have been switched to use the robot tag with the UnlockDoors and OnEnterRoom Events.

Added OnEnterRoom Event functionality: Used Andrea's system for the lab, but made it so the script can be reused with any tag. 

Event System Documentation has been updated to reflect this.

This work invlolved changing some tags on the npc prefabs as they were working incorrectly/using the wrong tag. That is why I had to update a lot of the prefabs.