### PR TITLE
Angel minigame bug(s)

### DIFF
--- a/Assets/Prefabs/Minigames/Angel/Station1Levers.prefab
+++ b/Assets/Prefabs/Minigames/Angel/Station1Levers.prefab
@@ -1,5 +1,123 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2337244936866420114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2601661905837419864}
+  - component: {fileID: 5140411813904222322}
+  - component: {fileID: 3872816543054383586}
+  m_Layer: 0
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2601661905837419864
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337244936866420114}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.31981242, y: 0.6312324, z: -0.62966275, w: -0.32060963}
+  m_LocalPosition: {x: 0.39088568, y: 4.1, z: 0.008}
+  m_LocalScale: {x: 0.3194719, y: 0.42197198, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 1478510234533566588}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -90}
+--- !u!108 &5140411813904222322
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337244936866420114}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 0
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 23.12
+  m_Range: 5.94
+  m_SpotAngle: 61.995365
+  m_InnerSpotAngle: 53.79744
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!114 &3872816543054383586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2337244936866420114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1 &5075589110911624067
 GameObject:
   m_ObjectHideFlags: 0
@@ -140,6 +258,7 @@ Transform:
   m_Children:
   - {fileID: 639039136056896891}
   - {fileID: 3539595772418265649}
+  - {fileID: 2601661905837419864}
   - {fileID: 6324622444020905868}
   - {fileID: 8633208822205262031}
   - {fileID: 476559313936291242}
@@ -232,6 +351,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _confirmButton: {fileID: 6239864622063204848}
+  _spotlight: {fileID: 2337244936866420114}
   _levers:
   - {fileID: 7819040297013888061}
   - {fileID: 5514671544636169086}

--- a/Assets/Prefabs/Minigames/Angel/Station2Dials.prefab
+++ b/Assets/Prefabs/Minigames/Angel/Station2Dials.prefab
@@ -313,6 +313,7 @@ Transform:
   m_Children:
   - {fileID: 2799951795460555742}
   - {fileID: 6504432895239205749}
+  - {fileID: 776811824712369557}
   - {fileID: 5430775832967009632}
   - {fileID: 593300292248614324}
   - {fileID: 9009466563128662997}
@@ -404,11 +405,130 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _confirmButton: {fileID: 8948676246992464829}
+  _spotlight: {fileID: 8989171259017074057}
   _dials:
   - {fileID: 3416847069398025831}
   - {fileID: 6510174453737711622}
   - {fileID: 148509665444807515}
   - {fileID: 5470666801921602456}
+--- !u!1 &8989171259017074057
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 776811824712369557}
+  - component: {fileID: 2804617206566172788}
+  - component: {fileID: 6661247580008846871}
+  m_Layer: 0
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &776811824712369557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8989171259017074057}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.31981242, y: 0.6312324, z: -0.62966275, w: -0.32060963}
+  m_LocalPosition: {x: 0.39088568, y: 4.1, z: 0}
+  m_LocalScale: {x: 0.3194719, y: 0.42197198, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 492207798732873794}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -90}
+--- !u!108 &2804617206566172788
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8989171259017074057}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 0
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 23.12
+  m_Range: 5.94
+  m_SpotAngle: 61.995365
+  m_InnerSpotAngle: 53.79744
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!114 &6661247580008846871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8989171259017074057}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1001 &289371624446071171
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Minigames/Angel/Station3Arrows.prefab
+++ b/Assets/Prefabs/Minigames/Angel/Station3Arrows.prefab
@@ -208,6 +208,7 @@ Transform:
   m_Children:
   - {fileID: 4115346540565137659}
   - {fileID: 7705743821448966474}
+  - {fileID: 2772309856926685001}
   - {fileID: 1456874946720840827}
   - {fileID: 3478204983488993365}
   - {fileID: 7888429682056347121}
@@ -300,6 +301,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _confirmButton: {fileID: 2547406200312840870}
+  _spotlight: {fileID: 6915892023122263836}
 --- !u!1 &4975845790190304649
 GameObject:
   m_ObjectHideFlags: 0
@@ -405,6 +407,124 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6915892023122263836
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2772309856926685001}
+  - component: {fileID: 7773300728849272235}
+  - component: {fileID: 7820224609740603807}
+  m_Layer: 0
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2772309856926685001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915892023122263836}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.31981242, y: 0.6312324, z: -0.62966275, w: -0.32060963}
+  m_LocalPosition: {x: 0.39088568, y: 4.1, z: 0}
+  m_LocalScale: {x: 0.3194719, y: 0.42197198, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 2051391390713087056}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -90}
+--- !u!108 &7773300728849272235
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915892023122263836}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 0
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 23.12
+  m_Range: 5.94
+  m_SpotAngle: 61.995365
+  m_InnerSpotAngle: 53.79744
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!114 &7820224609740603807
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6915892023122263836}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1001 &1257326188438238687
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Minigames/Angel/Station4Numbers.prefab
+++ b/Assets/Prefabs/Minigames/Angel/Station4Numbers.prefab
@@ -117,6 +117,124 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5369307429896780734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4671681953976848985}
+  - component: {fileID: 2041293232059590750}
+  - component: {fileID: 8232883642508617286}
+  m_Layer: 0
+  m_Name: Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &4671681953976848985
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5369307429896780734}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.31981242, y: 0.6312324, z: -0.62966275, w: -0.32060963}
+  m_LocalPosition: {x: 0.39088568, y: 4.1, z: 0}
+  m_LocalScale: {x: 0.3194719, y: 0.42197198, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 8306252062851878962}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -90}
+--- !u!108 &2041293232059590750
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5369307429896780734}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 0
+  m_Shape: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Intensity: 23.12
+  m_Range: 5.94
+  m_SpotAngle: 61.995365
+  m_InnerSpotAngle: 53.79744
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 0
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!114 &8232883642508617286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5369307429896780734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1 &6444609792324432405
 GameObject:
   m_ObjectHideFlags: 0
@@ -151,6 +269,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2450805361004388229}
+  - {fileID: 4671681953976848985}
   - {fileID: 6158281739388447600}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -238,6 +357,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _confirmButton: {fileID: 3597175863850953218}
+  _spotlight: {fileID: 5369307429896780734}
   _sequenceLength: 6
 --- !u!1 &8145115373310424908
 GameObject:

--- a/Assets/Scenes/AngelMini.unity
+++ b/Assets/Scenes/AngelMini.unity
@@ -195,7 +195,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
       propertyPath: _loopTimerTime
-      value: 180
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
       propertyPath: endScreenDelay

--- a/Assets/Scripts/InteractionSystem/InteractableObjects/LeverInteraction.cs
+++ b/Assets/Scripts/InteractionSystem/InteractableObjects/LeverInteraction.cs
@@ -38,7 +38,7 @@ public class LeverInteraction : MonoBehaviour, IInteractable
     /// <summary>
     ///  Displays the specific UI prompt
     /// </summary>
-    public void DisplayInteractUI()
+    public virtual void DisplayInteractUI()
     {
         TabbedMenu.Instance.ToggleInteractPrompt(true, "LEVER");
     }

--- a/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
@@ -110,7 +110,12 @@ public class AngelMinigameManager : MonoBehaviour
         if (_stationCount < _stations.Count && _stationCount >= 0)
         {
             _stations[_stationCount].StationScreen.SetActive(false);
+            _stations[_stationCount].StationBehavior.MakeStationUnconfirmable();
         }
+
+        SetSpotlight();
+        
+
         _stationCount++;
 
         StopAllCoroutines();
@@ -177,6 +182,24 @@ public class AngelMinigameManager : MonoBehaviour
     }
 
     /// <summary>
+    /// 
+    /// </summary>
+    private void SetSpotlight()
+    {
+        //turns off previous spotlight
+        if(_stationCount >= 0)
+        {
+            _stations[_stationCount].StationBehavior.SetSpotlight(false);
+        }
+
+        //enables next spotlight
+        if(_stationCount < _stations.Count - 1)
+        {
+            _stations[_stationCount + 1].StationBehavior.SetSpotlight(true);
+        }
+    }
+
+    /// <summary>
     /// Function called to start the minigame. Triggered by NpcEventListener
     /// looking for OnMinigameStart with tag Angel.
     /// </summary>
@@ -195,6 +218,8 @@ public class AngelMinigameManager : MonoBehaviour
         StopAllCoroutines();
         _timerText.text = "0:00";
         _endMinigameEvent.TriggerEvent(_endMinigameEventTag);
+        SetSpotlight();
+        _stations[_stationCount].StationBehavior.MakeStationUnconfirmable();
 
         if (_stationCount < _stations.Count && _stationCount >= 0)
         {

--- a/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
@@ -76,7 +76,7 @@ public class AngelMinigameManager : MonoBehaviour
             if(_round >= 3)
             {
                 //checks how many stations are left. This is based on how many stations
-                //are in the array, so if some ar ecut this will still work.
+                //are in the array, so if some are cut this will still work.
                 if(_stationCount < _stations.Count - 1)
                 {
                     _round = 0;
@@ -89,15 +89,23 @@ public class AngelMinigameManager : MonoBehaviour
             }
             else
             {
+                //correct answer
                 StartStation();
-                print("correct");
             }
         }
         else
         {
+            //wrong answer
             StartStation();
-            print("wrong");
+
+            //decrease round count on failure if not at 0
+            if(_round > 0)
+            {
+                _round --;
+            }
         }
+
+        //print(_round);
     }
 
     /// <summary>

--- a/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/AngelMinigameManager.cs
@@ -190,7 +190,8 @@ public class AngelMinigameManager : MonoBehaviour
     }
 
     /// <summary>
-    /// 
+    /// This function manages turning the spotlights on and off at the begining of 
+    /// the game, then the station switches, and at the end of the game.
     /// </summary>
     private void SetSpotlight()
     {
@@ -235,5 +236,12 @@ public class AngelMinigameManager : MonoBehaviour
         }
         _winScreen.SetActive(true);
         print("game over");
+    }
+
+    private void OnDisable()
+    {
+        AngelStationComplete -= SwitchStation;
+        CheckState -= CheckStates;
+        TriggerFail -= StartStation;
     }
 }

--- a/Assets/Scripts/Minigames/AngelMinigame/ClearLever.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/ClearLever.cs
@@ -9,6 +9,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using PlaceboEntertainment.UI;
 
 public class ClearLever : LeverInteraction
 {
@@ -43,5 +44,13 @@ public class ClearLever : LeverInteraction
     private void SetLeverDelayHelper()
     {
         SetLever(true);
+    }
+
+    /// <summary>
+    /// Changes the lever interaction prompt to say clear instead of lever.
+    /// </summary>
+    public override void DisplayInteractUI()
+    {
+        TabbedMenu.Instance.ToggleInteractPrompt(true, "CLEAR");
     }
 }

--- a/Assets/Scripts/Minigames/AngelMinigame/Station1.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/Station1.cs
@@ -48,6 +48,7 @@ public class Station1 : StationBehavior
 
     public override void RestartStationState()
     {
+        print(_levers[0]);
         foreach (GameObject lever in _levers)
         {
             lever.GetComponent<LeverInteraction>().SetLever(false);

--- a/Assets/Scripts/Minigames/AngelMinigame/Station1.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/Station1.cs
@@ -48,7 +48,6 @@ public class Station1 : StationBehavior
 
     public override void RestartStationState()
     {
-        print(_levers[0]);
         foreach (GameObject lever in _levers)
         {
             lever.GetComponent<LeverInteraction>().SetLever(false);
@@ -77,5 +76,11 @@ public class Station1 : StationBehavior
         }
 
         return _leversCorrectStateInt;
+    }
+
+    private void OnDisable()
+    {
+        AngelMinigameManager.TriggerStart -= RestartStationState;
+        AngelMinigameManager.TriggerFail -= RestartStationState;
     }
 }

--- a/Assets/Scripts/Minigames/AngelMinigame/StationBehavior.cs
+++ b/Assets/Scripts/Minigames/AngelMinigame/StationBehavior.cs
@@ -16,6 +16,7 @@ using UnityEngine;
 public class StationBehavior : MonoBehaviour
 {
     [SerializeField] private GameObject _confirmButton;
+    [SerializeField] private GameObject _spotlight;
 
     /// <summary>
     /// The confirm button calls this functin from an action in the minigame manager.
@@ -66,5 +67,21 @@ public class StationBehavior : MonoBehaviour
     public void MakeStationUnconfirmable()
     {
         _confirmButton.GetComponent<ButtonInteraction>().IsInteractable = false;
+    }
+
+    /// <summary>
+    /// This function allows for the minigame manager to enable and disable the spotlight.
+    /// </summary>
+    /// <param name="light"></param>
+    public void SetSpotlight(bool light)
+    {
+        if(light)
+        {
+            _spotlight.SetActive(true);
+        }
+        else
+        {
+            _spotlight.SetActive(false);
+        }
     }
 }


### PR DESCRIPTION
All changes can be tested in the angel mingame scene

Bug where on the second loop buttons would not work: Added On Disable functions for the actions in the minigame manager and station 1 scripts. Was able to test and play through the minigame game successfully through 3 different loops.

Bug where the new inputs do not get put on the screen after a failure:  I was unable to recreate this bug after fixing the first bug, I believe it may have had to do with the errors produced from that.

The active station will now be lit up. There is a light object attatched to each station, and its color and intensity can be changed as art/design deem fit.

Failure to input the corred code by the timer now decreases the successful round count if it is not already at 0. If you do a station correctly once, then mess up, you will have to do it three more times to pass that station.