### PR TITLE
Meta progression

### DIFF
--- a/Assets/Scripts/InventoryScripts/InventorySystem.cs
+++ b/Assets/Scripts/InventoryScripts/InventorySystem.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.VisualScripting.FullSerializer;
 using UnityEngine;
 
 [System.Serializable]
@@ -69,6 +70,7 @@ public class InventorySystem
                             AddedToInventory?.Invoke(itemToAdd, overflowAmount);
                             overflowAmount = 0;
                             addedAnyItems = true;
+                            SaveLoadManager.Instance.SaveGameToSaveFile();
                             return true; // All items added
                         }
                         else
@@ -77,6 +79,7 @@ public class InventorySystem
                             overflowAmount -= roomLeft;
                             AddedToInventory?.Invoke(itemToAdd, roomLeft);
                             addedAnyItems = true;
+                            SaveLoadManager.Instance.SaveGameToSaveFile();
                         }
                     }
                 }
@@ -91,6 +94,7 @@ public class InventorySystem
                     AddedToInventory?.Invoke(itemToAdd, overflowAmount);
                     overflowAmount = 0;
                     addedAnyItems = true;
+                    SaveLoadManager.Instance.SaveGameToSaveFile();
                     return true; // All items added
                 }
                 else
@@ -99,6 +103,7 @@ public class InventorySystem
                     overflowAmount -= maxStack;
                     AddedToInventory?.Invoke(itemToAdd, maxStack);
                     addedAnyItems = true;
+                    SaveLoadManager.Instance.SaveGameToSaveFile();
                 }
             }
             else

--- a/Assets/Scripts/InventoryScripts/InventorySystem.cs
+++ b/Assets/Scripts/InventoryScripts/InventorySystem.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.VisualScripting.FullSerializer;
 using UnityEngine;
 
 [System.Serializable]

--- a/Assets/Scripts/Saving/SaveLoadManager.cs
+++ b/Assets/Scripts/Saving/SaveLoadManager.cs
@@ -87,7 +87,7 @@ public class SaveLoadManager : MonoBehaviour
         }
         else
         {
-            print("Dun goofed, save file doesnt exist at given location");
+            print("Save file doesnt exist at given location");
         }
         return temp;
     }


### PR DESCRIPTION
Confirmed that beating the game does actually delete your save file. 

While digging on the issue, I discovered that items might not have been added to the save file when they were added to the inventory. I pushed this quick fix to ensure that none get left behind.

If the reviewer could please also confirm that:
A. Collecting meta items wrench and translation book but failing/resetting keeps them in your inventory (file is loaded) upon trying again. Looking at the inventory holder on the Player gameobject should be sufficient. You can also check the SAV file on your computer by searching for LocalLow or .sav file extension, mine pulls right up in my file explorer. 
B. Beating the game and then talking to the angel to finish ends the game and deletes the file. I confirmed this by checking the debug.log in the console upon exiting/ starting the game again, it gives a file not found text. Your inventory holder should also be empty. Once you pick up an item to add it to your inventory, the game then in turn saves to a newly created file. 