### PR TITLE
Countdown BugFix

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -55576,15 +55576,31 @@ PrefabInstance:
       value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
+      propertyPath: _temporaryTag
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
       propertyPath: temporaryLoop
       value: 
       objectReference: {fileID: 11400000, guid: 3ecd2838e2ea86b42a087aad7f6a97a6, type: 2}
+    - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
+      propertyPath: _loopTimerName
+      value: LoopTimer
+      objectReference: {fileID: 0}
     - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
       propertyPath: _loopTimerTime
       value: 360
       objectReference: {fileID: 0}
     - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
+      propertyPath: _temporaryLoop
+      value: 
+      objectReference: {fileID: 11400000, guid: 3ecd2838e2ea86b42a087aad7f6a97a6, type: 2}
+    - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
       propertyPath: endScreenDelay
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 578804054939250850, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}
+      propertyPath: _endScreenDelay
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5278445670614390501, guid: bca78430ba974e94ca8da7d4c3236332, type: 3}

--- a/Assets/Scripts/Loop/LoopController.cs
+++ b/Assets/Scripts/Loop/LoopController.cs
@@ -7,6 +7,7 @@
 *******************************************************************/
 
 using UnityEngine;
+using System.Collections.Generic;
 using UnityEngine.SceneManagement;
 
 public class LoopController : MonoBehaviour
@@ -20,9 +21,22 @@ public class LoopController : MonoBehaviour
     public int LoopTimerTimer => _loopTimerTime;
     public string LoopTimerName => _loopTimerName;
 
+    private List<Timer> _runningTimersAtStart = new List<Timer>();
+    private List<Timer> _pausedTimersAtStart= new List<Timer>();
+
     private void Start()
     {
-        //Creating a timer. 
+        foreach(TimerStruct timer in TimerManager.Instance._timers)
+        {
+            if(timer.timer.IsRunning())
+            {
+                _runningTimersAtStart.Add(timer.timer);
+            }
+            else if (!timer.timer.IsRunning())
+            {
+                _pausedTimersAtStart.Add(timer.timer);  
+            }
+        }
         _loopTimer = TimerManager.Instance.CreateTimer(LoopTimerName, _loopTimerTime + _endScreenDelay, _temporaryLoop, _temporaryTag);
         //_loopTimer.TimesUp += HandleLoopTimerEnd;
         LoadSave();
@@ -43,7 +57,15 @@ public class LoopController : MonoBehaviour
     /// </summary>
     public void ResetLoop()
     {
-        TimerManager.Instance.RemoveTimer(LoopTimerName);
+        foreach(Timer timer in  _runningTimersAtStart)
+        {
+            timer.ResetTimer();
+            timer.StartTimer();
+        }
+        foreach (Timer timer in _pausedTimersAtStart)
+        {
+            timer.ResetTimer();
+        }
         SaveLoadManager.Instance.SaveGameToSaveFile();
         int activeSceneIndex = SceneManager.GetActiveScene().buildIndex;
         SceneManager.LoadScene(activeSceneIndex);

--- a/Assets/Scripts/Loop/LoopController.cs
+++ b/Assets/Scripts/Loop/LoopController.cs
@@ -12,17 +12,18 @@ using UnityEngine.SceneManagement;
 public class LoopController : MonoBehaviour
 {
     private Timer _loopTimer;
+    [SerializeField] private string _loopTimerName;
     [SerializeField] private int _loopTimerTime;
-    [SerializeField] private int endScreenDelay;
-
-    [SerializeField] private NpcEvent temporaryLoop;
-    [SerializeField] private NpcEventTags temporaryTag;
+    [SerializeField] private int _endScreenDelay;
+    [SerializeField] private NpcEvent _temporaryLoop;
+    [SerializeField] private NpcEventTags _temporaryTag;
     public int LoopTimerTimer => _loopTimerTime;
+    public string LoopTimerName => _loopTimerName;
 
     private void Start()
     {
         //Creating a timer. 
-        _loopTimer = TimerManager.Instance.CreateTimer("LoopTimer", _loopTimerTime + endScreenDelay, temporaryLoop, temporaryTag);
+        _loopTimer = TimerManager.Instance.CreateTimer(LoopTimerName, _loopTimerTime + _endScreenDelay, _temporaryLoop, _temporaryTag);
         //_loopTimer.TimesUp += HandleLoopTimerEnd;
         LoadSave();
     }
@@ -31,7 +32,7 @@ public class LoopController : MonoBehaviour
     /// </summary>
     private void HandleLoopTimerEnd()
     {
-        TimerManager.Instance.RemoveTimer("LoopTimer");
+        TimerManager.Instance.RemoveTimer(LoopTimerName);
 
         ResetLoop();
 
@@ -42,6 +43,7 @@ public class LoopController : MonoBehaviour
     /// </summary>
     public void ResetLoop()
     {
+        TimerManager.Instance.RemoveTimer(LoopTimerName);
         SaveLoadManager.Instance.SaveGameToSaveFile();
         int activeSceneIndex = SceneManager.GetActiveScene().buildIndex;
         SceneManager.LoadScene(activeSceneIndex);


### PR DESCRIPTION
Added a small bit of code to the LoopController script (specifically the ResetLoop method) and updated some values' names

Edited the LoopTimer in the timermanager prefab list in the main scene 

Now, when the scene is reloaded and LoopController goes to make the main timer, it's not trying to duplicate an already existing timer. (Which isn't allowed, resulting in the previous timer continuing with the incorrect time) Additionally, any timers engine team makes in the inspector, running or not, will be reloaded upon the game reset. Timers made through scripts will be made anyways when the scripts run again. 

I tested by setting the time in LoopController to 5 seconds to see the game reset and begin the countdown clock again, which it does without complaint. 