### PR TITLE
Camera Snapping After Dialogue Fix

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -125,13 +125,25 @@ public class PlayerController : MonoBehaviour
     {
         _isInDialogue = isLocked;
 
-        // Preventing camera from snapping after dialogue
-        if (!isLocked)
+        if (isLocked)
         {
-            _mainCamera.transform.rotation = transform.rotation;
+            CinemachineCore.UniformDeltaTimeOverride = 0;
+        }
+        else
+        {
+            Invoke(nameof(DelayedCameraUnlock), 0.075f);
+            _mainCamera.transform.eulerAngles = transform.forward;
         }
 
         _mainCamera.gameObject.SetActive(!isLocked);
+    }
+
+    /// <summary>
+    /// Helper function inovoked to delay regaining camera control post-dialogue
+    /// </summary>
+    private void DelayedCameraUnlock()
+    {
+        CinemachineCore.UniformDeltaTimeOverride = 1;
     }
 
     /// <summary>

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -131,7 +131,7 @@ public class PlayerController : MonoBehaviour
         }
         else
         {
-            Invoke(nameof(DelayedCameraUnlock), 0.075f);
+            Invoke(nameof(DelayedCameraUnlock), 0.1f);
             _mainCamera.transform.eulerAngles = transform.forward;
         }
 
@@ -143,7 +143,8 @@ public class PlayerController : MonoBehaviour
     /// </summary>
     private void DelayedCameraUnlock()
     {
-        CinemachineCore.UniformDeltaTimeOverride = 1;
+        if (!_isInDialogue)
+            CinemachineCore.UniformDeltaTimeOverride = 1;
     }
 
     /// <summary>


### PR DESCRIPTION
I added a small delay between the player being "unlocked" after dialogue and the cinemachine being able to move/read input which should stop the camera from snapping as the player exits dialogue.