### PR TITLE
Wire count bug

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -18019,6 +18019,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 369651554}
   - {fileID: 1115980966}
   - {fileID: 1482132440}
   - {fileID: 1428089521}
@@ -18284,7 +18285,7 @@ GameObject:
   - component: {fileID: 369651552}
   m_Layer: 0
   m_Name: Robo
-  m_TagString: Untagged
+  m_TagString: WireManager
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -18302,6 +18303,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _gameWonEvent: {fileID: 11400000, guid: 8b7b5ccfabcfc4d4f96da8928978e41e, type: 2}
+  _maxAttachments: 3
+  ListOfWireSlots: []
 --- !u!114 &369651553
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18322,12 +18325,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 369651551}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.52, y: 2.67, z: 7.37}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -25.621107, y: 256.41772, z: 359.01477}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 362340145}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &374410353
 GameObject:
@@ -64534,7 +64537,6 @@ SceneRoots:
   - {fileID: 362340145}
   - {fileID: 106151019}
   - {fileID: 2094144432}
-  - {fileID: 369651554}
   - {fileID: 492889397}
   - {fileID: 1996449659}
   - {fileID: 1749669357}

--- a/Assets/Scenes/TestGyms/RobotMini.unity
+++ b/Assets/Scenes/TestGyms/RobotMini.unity
@@ -204,7 +204,7 @@ GameObject:
   - component: {fileID: 227778407}
   m_Layer: 0
   m_Name: Robo
-  m_TagString: Untagged
+  m_TagString: WireManager
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -249,6 +249,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _gameWonEvent: {fileID: 11400000, guid: 6c063e0dc7b42fc4e8a3e9c06253b1c1, type: 2}
+  _maxAttachments: 3
+  ListOfWireSlots: []
 --- !u!1001 &270001406
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -401,6 +403,10 @@ PrefabInstance:
     - target: {fileID: 184720611215862423, guid: c305122b038e6e048b647787017c7c42, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.5211685
+      objectReference: {fileID: 0}
+    - target: {fileID: 184720611215862423, guid: c305122b038e6e048b647787017c7c42, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4607649
       objectReference: {fileID: 0}
     - target: {fileID: 184720611215862423, guid: c305122b038e6e048b647787017c7c42, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scripts/Minigames/WireGame/MGWireSlot.cs
+++ b/Assets/Scripts/Minigames/WireGame/MGWireSlot.cs
@@ -19,6 +19,7 @@ public class MGWireSlot : MonoBehaviour
     [SerializeField] private MGWire.EWireID _matchingWire;
     [SerializeField] private MeshRenderer _slotRenderer;
     [SerializeField] private Color _slotColor;
+    [HideInInspector] public bool IsConnected;
 
     [Header("VFX Stuff")]
     [SerializeField] private ParticleSystem _connectSpark;
@@ -30,6 +31,10 @@ public class MGWireSlot : MonoBehaviour
     private void Start()
     {
         _slotRenderer.material.color = _slotColor;
+
+        //Adds To Slot List in Wire State Script
+        GameObject robo = GameObject.FindWithTag("WireManager");
+        robo.GetComponent<MGWireState>().ListOfWireSlots.Add(this);
     }
 
     /*private void OnDrawGizmos()
@@ -46,8 +51,11 @@ public class MGWireSlot : MonoBehaviour
         Assert.IsNotNull(wire, "Make sure the object passed in is a " +
             "valid wire");
 
+        IsConnected = false;
+
         if(wire.WireID.Equals(_matchingWire))
         {
+            IsConnected = true;
             CorrectWire?.Invoke();
             _disconnectedSparks.Stop();
             _connectSpark.Play();

--- a/Assets/Scripts/Minigames/WireGame/MGWireState.cs
+++ b/Assets/Scripts/Minigames/WireGame/MGWireState.cs
@@ -16,8 +16,10 @@ public class MGWireState : MonoBehaviour
     public static Action WireGameWon;
     [SerializeField] private NpcEvent _gameWonEvent;
 
-    private const int _maxAttachments = 3;
+    [SerializeField] private int _maxAttachments; // = 3;
     private int _currentAttachments = 0;
+
+    public List<MGWireSlot> ListOfWireSlots;
 
     private void OnEnable()
     {
@@ -35,10 +37,23 @@ public class MGWireState : MonoBehaviour
     /// </summary>
     private void AttachedWire()
     {
-        if(++_currentAttachments == _maxAttachments)
+        //counts how many wires are connected
+        foreach(MGWireSlot wireSlot in ListOfWireSlots)
+        {
+            if(wireSlot.IsConnected)
+            {
+                ++_currentAttachments;
+            }
+        }
+        
+        //checks if enough wires are connected to end the game
+        if (_currentAttachments >= _maxAttachments)
         {
             EndWireGame();
         }
+
+        //resets count
+        _currentAttachments = 0;
     }
 
     /// <summary>

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,6 +12,7 @@ TagManager:
   - Water
   - Fire
   - RightArm
+  - WireManager
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
I made a few changes to the wire minigame scripts. I changed the game end's condition to check if all the slots have the correctly slotted wire, not just count how many times a correct wire has been placed.