### PR TITLE
Robot Dialogue Bug

### DIFF
--- a/Assets/Prefabs/NPCs/Robot.prefab
+++ b/Assets/Prefabs/NPCs/Robot.prefab
@@ -304,7 +304,17 @@ MonoBehaviour:
         _nextResponseIndex: 
         _advancesNpcState: 0
         _endsDialogue: 1
-    _failureState: []
+    _failureState:
+    - _dialogue:
+      - '[The dead Robot is unresponsive]'
+      _playerResponses:
+      - _eventToTrigger: {fileID: 0}
+        _eventTag: 0
+        _hasPrerequisiteCheck: 0
+        _answer: <b>Leave
+        _nextResponseIndex: 
+        _advancesNpcState: 0
+        _endsDialogue: 1
   _navigationPositions:
     _idleState: {x: 0, y: 0, z: 0}
     _minigameReadyState: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/NpcBehaviors/BaseNpc.cs
+++ b/Assets/Scripts/NpcBehaviors/BaseNpc.cs
@@ -247,8 +247,12 @@ public abstract class BaseNpc : MonoBehaviour
             _isInteracting = false;
             _shouldEndDialogue = false;
             _tabbedMenu.ToggleDialogue(false);
-            _playerController.LockCharacter(false);
             _playerInteractBehavior.StartDetectingInteractions();
+
+            // Prevents camera jittering when trying to talk to an NPC with no dialogue
+            if (_stateDialogueTrees.GetStateData(_currentState).Length > 0)
+                _playerController.LockCharacter(false);
+
             return;
         }
 

--- a/Assets/Scripts/NpcBehaviors/BaseNpc.cs
+++ b/Assets/Scripts/NpcBehaviors/BaseNpc.cs
@@ -247,11 +247,8 @@ public abstract class BaseNpc : MonoBehaviour
             _isInteracting = false;
             _shouldEndDialogue = false;
             _tabbedMenu.ToggleDialogue(false);
+            _playerController.LockCharacter(false);
             _playerInteractBehavior.StartDetectingInteractions();
-
-            // Prevents camera jittering when trying to talk to an NPC with no dialogue
-            if (_stateDialogueTrees.GetStateData(_currentState).Length > 0)
-                _playerController.LockCharacter(false);
 
             return;
         }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -123,6 +123,10 @@ public class PlayerController : MonoBehaviour
     /// <param name="isLocked">Whether the player should move or not</param>
     public void LockCharacter(bool isLocked)
     {
+        // Stops the camera from jittering interacting with NPCs that have no dialogue
+        if (_isInDialogue == isLocked)
+            return;
+
         _isInDialogue = isLocked;
 
         if (isLocked)


### PR DESCRIPTION
Made a small code change to prevent the camera from jittering when talking to an NPC that has no dialogue in its current state. Also, gave the Robot a temporary message in its death state to make it clearer that it has died.