### PR TITLE
arm disapearing bug

### DIFF
--- a/Assets/Animation/Player/Player.controller
+++ b/Assets/Animation/Player/Player.controller
@@ -11,7 +11,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -2765917800072929274}
+  - {fileID: 1137789831505013714}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -27,56 +27,6 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-3437639362453796268
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 2
-    m_ConditionEvent: _isSwinging
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -7109208118005871113}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.516129
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
---- !u!1101 &-2765917800072929274
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: _isSwinging
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 4041020166908818459}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 1
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 0
-  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -88,6 +38,12 @@ AnimatorController:
   m_AnimatorParameters:
   - m_Name: _isSwinging
     m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: _swing
+    m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -105,6 +61,53 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &1137789831505013714
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: _swing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4041020166908818459}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3750117454746277114
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7109208118005871113}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0.25
+  m_ExitTime: 1
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &4041020166908818459
 AnimatorState:
   serializedVersion: 6
@@ -116,7 +119,7 @@ AnimatorState:
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
-  - {fileID: -3437639362453796268}
+  - {fileID: 3750117454746277114}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Prefabs/Fullplayer.prefab
+++ b/Assets/Prefabs/Fullplayer.prefab
@@ -70,7 +70,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &468400467487777756
 Transform:
   m_ObjectHideFlags: 0
@@ -101,7 +101,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2344608641352682661}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -970,9 +970,25 @@ PrefabInstance:
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: -1655326984900760386, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.08281061
+      objectReference: {fileID: 0}
+    - target: {fileID: -1655326984900760386, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.00000006298069
+      objectReference: {fileID: 0}
+    - target: {fileID: -1655326984900760386, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.00000086426735
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 181e0f60aa96898439463e934679e17f, type: 3}
       propertyPath: m_Name
       value: Player_model_rigged
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627878768863445961, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+      propertyPath: m_TagString
+      value: RightArm
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -980,13 +996,42 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: -1655326984900760386, guid: 181e0f60aa96898439463e934679e17f, type: 3}
       insertIndex: 0
       addedObject: {fileID: 468400467487777756}
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8627878768863445961, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5438411252519148417}
   m_SourcePrefab: {fileID: 100100000, guid: 181e0f60aa96898439463e934679e17f, type: 3}
 --- !u!4 &3060783897011670624 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -1655326984900760386, guid: 181e0f60aa96898439463e934679e17f, type: 3}
   m_PrefabInstance: {fileID: 4863058962913878750}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &3801438700345188631 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8627878768863445961, guid: 181e0f60aa96898439463e934679e17f, type: 3}
+  m_PrefabInstance: {fileID: 4863058962913878750}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &5438411252519148417
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3801438700345188631}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 000925edced932647bfa88527db36a67, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 1
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!4 &4969642066339398965 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 181e0f60aa96898439463e934679e17f, type: 3}

--- a/Assets/Scripts/Minigames/CowardMiniGame/WrenchBehavior.cs
+++ b/Assets/Scripts/Minigames/CowardMiniGame/WrenchBehavior.cs
@@ -96,15 +96,12 @@ public class WrenchBehavior : MonoBehaviour, IInteractable
     /// <returns></returns>
     IEnumerator Swinging()
     {
-        //print("swing");
         GetComponent<Collider>().enabled = true;
-        //_animate.SetBool("_isSwinging", true);
         _animate.SetTrigger("_swing");
-        //_swing = true;
+
         yield return new WaitForSeconds(1f);
-        //_swing = false;
+
         GetComponent<Collider>().enabled = false;
-        //_animate.SetBool("_isSwinging", false);
     }
     IEnumerator SystematicShutDown()
     {

--- a/Assets/Scripts/Minigames/CowardMiniGame/WrenchBehavior.cs
+++ b/Assets/Scripts/Minigames/CowardMiniGame/WrenchBehavior.cs
@@ -98,12 +98,13 @@ public class WrenchBehavior : MonoBehaviour, IInteractable
     {
         //print("swing");
         GetComponent<Collider>().enabled = true;
-        _animate.SetBool("_isSwinging", true);
+        //_animate.SetBool("_isSwinging", true);
+        _animate.SetTrigger("_swing");
         //_swing = true;
         yield return new WaitForSeconds(1f);
         //_swing = false;
         GetComponent<Collider>().enabled = false;
-        _animate.SetBool("_isSwinging", false);
+        //_animate.SetBool("_isSwinging", false);
     }
     IEnumerator SystematicShutDown()
     {


### PR DESCRIPTION
The arm was moving due to the wrench swinging animation, and then not moving back to its original poistion to it was not in view of the player. I switched the animation to be a trigger instead of a bool so that the arm always returns to its original position, even after the wrench object is destroyed. 

In the playthrough videos the arm would disapear after using the wrench, and I was not able to replicate the fish making the arm disapear. If anyone has more information about this I can look again, but if not and this is still a problem it should be brought up again as its own bug report.