### PR TITLE
added in 30 second timers

### DIFF
--- a/Assets/Prefabs/TimerManager.prefab
+++ b/Assets/Prefabs/TimerManager.prefab
@@ -46,10 +46,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _timers:
-  - timerName: LoopTimer
+  - timerName: Example
     timer:
       _maxTime: 600
-      _isRunning: 1
+      _isRunning: 0
       _eventTimerCalls: {fileID: 11400000, guid: 3ecd2838e2ea86b42a087aad7f6a97a6, type: 2}
       _NPCToAlert: 8
   - timerName: RobotDeathTimer
@@ -70,11 +70,29 @@ MonoBehaviour:
       _isRunning: 1
       _eventTimerCalls: {fileID: 11400000, guid: 3ecd2838e2ea86b42a087aad7f6a97a6, type: 2}
       _NPCToAlert: 7
-  - timerName: LoopTimer
+  - timerName: ShipFailTimer
     timer:
       _maxTime: 600
       _isRunning: 1
       _eventTimerCalls: {fileID: 11400000, guid: 3ecd2838e2ea86b42a087aad7f6a97a6, type: 2}
+      _NPCToAlert: 8
+  - timerName: 30SecondsGeneratorPlusDelay
+    timer:
+      _maxTime: 145
+      _isRunning: 1
+      _eventTimerCalls: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
+      _NPCToAlert: 6
+  - timerName: 30SecondsFirePlusDelay
+    timer:
+      _maxTime: 325
+      _isRunning: 1
+      _eventTimerCalls: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
+      _NPCToAlert: 7
+  - timerName: 30SecondsShipPlusDelay
+    timer:
+      _maxTime: 565
+      _isRunning: 1
+      _eventTimerCalls: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
       _NPCToAlert: 8
 --- !u!114 &7371263332850259969
 MonoBehaviour:
@@ -106,6 +124,18 @@ MonoBehaviour:
             m_StringArgument: GeneratorExplodeTimer
             m_BoolArgument: 0
           m_CallState: 2
+        - m_Target: {fileID: 8988970857005786147}
+          m_TargetAssemblyTypeName: TimerManager, Assembly-CSharp
+          m_MethodName: RemoveTimerNoReturn
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 30SecondsGeneratorPlusDelay
+            m_BoolArgument: 0
+          m_CallState: 2
   - _npcEvent: {fileID: 11400000, guid: fc8258980d4d13341abe42a88ac6fdb6, type: 2}
     _npcEventTag: 2
     _onEventTriggered:
@@ -123,6 +153,18 @@ MonoBehaviour:
             m_StringArgument: FireFailTimer
             m_BoolArgument: 0
           m_CallState: 2
+        - m_Target: {fileID: 8988970857005786147}
+          m_TargetAssemblyTypeName: TimerManager, Assembly-CSharp
+          m_MethodName: RemoveTimerNoReturn
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 30SecondsFirePlusDelay
+            m_BoolArgument: 0
+          m_CallState: 2
   - _npcEvent: {fileID: 11400000, guid: fc8258980d4d13341abe42a88ac6fdb6, type: 2}
     _npcEventTag: 0
     _onEventTriggered:
@@ -137,6 +179,18 @@ MonoBehaviour:
             m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
             m_IntArgument: 0
             m_FloatArgument: 0
-            m_StringArgument: LoopTimer
+            m_StringArgument: ShipFailTimer
+            m_BoolArgument: 0
+          m_CallState: 2
+        - m_Target: {fileID: 8988970857005786147}
+          m_TargetAssemblyTypeName: TimerManager, Assembly-CSharp
+          m_MethodName: RemoveTimerNoReturn
+          m_Mode: 5
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 30SecondsShipPlusDelay
             m_BoolArgument: 0
           m_CallState: 2

--- a/Assets/Prefabs/UI/TabbedMenu.prefab
+++ b/Assets/Prefabs/UI/TabbedMenu.prefab
@@ -58,6 +58,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5028407268189074725}
   - component: {fileID: 4422286474446707533}
+  - component: {fileID: 4109945314516181468}
   m_Layer: 5
   m_Name: TabbedMenu
   m_TagString: Untagged
@@ -127,6 +128,121 @@ MonoBehaviour:
   - {fileID: 2800000, guid: bce0cce52a02bc2478305533fec3e3cd, type: 3}
   - {fileID: 2800000, guid: 4ed264664ecf7be44be5ef7f58ec3d66, type: 3}
   - {fileID: 2800000, guid: 62d28c9671d6fcb40a465bdd73cb5baa, type: 3}
+--- !u!114 &4109945314516181468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3268437976918378075}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a0acc881a336094997b0fb61c6d1983, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _eventsToListenFor:
+  - _npcEvent: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
+    _npcEventTag: 6
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenActive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _npcEvent: {fileID: 11400000, guid: fc8258980d4d13341abe42a88ac6fdb6, type: 2}
+    _npcEventTag: 1
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenUnactive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _npcEvent: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
+    _npcEventTag: 7
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenActive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _npcEvent: {fileID: 11400000, guid: fc8258980d4d13341abe42a88ac6fdb6, type: 2}
+    _npcEventTag: 2
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenUnactive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _npcEvent: {fileID: 11400000, guid: 718aa8d808aa79a40abc3266d2f16f80, type: 2}
+    _npcEventTag: 8
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenActive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _npcEvent: {fileID: 11400000, guid: fc8258980d4d13341abe42a88ac6fdb6, type: 2}
+    _npcEventTag: 0
+    _onEventTriggered:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 4422286474446707533}
+          m_TargetAssemblyTypeName: PlaceboEntertainment.UI.TabbedMenu, Assembly-CSharp
+          m_MethodName: SetLoseScreenUnactive
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &3315120248618835843
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
updated the timer manager prefab to add timers for 35 seconds before each death timer. 30 seconds for the countdown and then the 5 second delay after the countdown before the scene resets.

Added an event listener to the tabbed menu prefab to listen to the 30 seconds left event and timer end events to start and stop the countdown.

In the tabbed menu cs file i removed the code that would find the loop timer as it is better for it to be event driven and not in update. 