### PR TITLE
Nav Mesh Warning Fix

### DIFF
--- a/Assets/Prefabs/NPCs/Angel.prefab
+++ b/Assets/Prefabs/NPCs/Angel.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 4709515961060734939}
   - component: {fileID: 305925661611486817}
   - component: {fileID: 2972184706931071149}
-  - component: {fileID: 8168880049621234537}
   - component: {fileID: 7988089871590522290}
   - component: {fileID: 5859531997285546574}
   - component: {fileID: 2258230827953379646}
@@ -113,28 +112,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!195 &8168880049621234537
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7046988710313692951}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 1
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &7988089871590522290
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCs/Coward.prefab
+++ b/Assets/Prefabs/NPCs/Coward.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 3168306894194644997}
   - component: {fileID: 812672747345851475}
   - component: {fileID: 3710154545553647601}
-  - component: {fileID: 5906817822273611618}
   - component: {fileID: 1230460638816517745}
   - component: {fileID: 4840030442360983682}
   - component: {fileID: 5883686602139835072}
@@ -103,28 +102,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!195 &5906817822273611618
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3297066376343357550}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 1
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &1230460638816517745
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCs/Fish.prefab
+++ b/Assets/Prefabs/NPCs/Fish.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 7760235768858286636}
   - component: {fileID: 190002347449952546}
   - component: {fileID: 1608744599569339440}
-  - component: {fileID: 4903026629208649315}
   - component: {fileID: 1119676214051789975}
   - component: {fileID: 5239405601287651569}
   - component: {fileID: -562392636092693123}
@@ -103,28 +102,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!195 &4903026629208649315
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1813159210467846255}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 1
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &1119676214051789975
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCs/Goop.prefab
+++ b/Assets/Prefabs/NPCs/Goop.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 3241478675477886158}
   - component: {fileID: 190002347449952546}
   - component: {fileID: 1608744599569339440}
-  - component: {fileID: 4903026629208649315}
   - component: {fileID: -3603000809444628348}
   - component: {fileID: 3356181948352045349}
   - component: {fileID: 4560596353947037845}
@@ -113,28 +112,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!195 &4903026629208649315
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1813159210467846255}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 1
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &-3603000809444628348
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NPCs/Robot.prefab
+++ b/Assets/Prefabs/NPCs/Robot.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 5155935945816834384}
   - component: {fileID: 5615582337182177422}
   - component: {fileID: 9144484468842581267}
-  - component: {fileID: 3131129064344898019}
   - component: {fileID: 869825619415053396}
   - component: {fileID: 6882198576666297318}
   - component: {fileID: 2523090471910584266}
@@ -103,28 +102,6 @@ CapsuleCollider:
   m_Height: 2
   m_Direction: 1
   m_Center: {x: 0, y: 0, z: 0}
---- !u!195 &3131129064344898019
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4556153407337933796}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 1
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!114 &869825619415053396
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NpcBehaviors/BaseNpc.cs
+++ b/Assets/Scripts/NpcBehaviors/BaseNpc.cs
@@ -106,7 +106,6 @@ public abstract class BaseNpc : MonoBehaviour
     [SerializeField] protected NpcEventTags _eventTag;
 
     [SerializeField] protected StateDataGroup<DialogueNode[]> _stateDialogueTrees;
-    [SerializeField] protected StateDataGroup<Vector3> _navigationPositions;
     [SerializeField] protected StateDataGroup<Animation> _stateAnimations;
 
     protected NavMeshAgent _navAgent;
@@ -410,12 +409,6 @@ public abstract class BaseNpc : MonoBehaviour
     /// </summary>
     private void StateUpdateHelper()
     {
-        if (_navAgent != null && _navAgent.isOnNavMesh)
-        {
-            Vector3 newPosition = _navigationPositions.GetStateData(_currentState);
-            _navAgent.SetDestination(newPosition);
-        }
-
         if (_animator != null)
         {
             Animation newAnimation = _stateAnimations.GetStateData(_currentState);


### PR DESCRIPTION
Removed the nav mesh agent components from each NPC prefab, as well as a small amount of code related to those components from the BaseNPC script.