### PR TITLE
Progression Fixes

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -191,10 +191,13 @@ public class AudioManager : MonoBehaviour
             eventInstanceWorldDict.Add(instance, attachObject);
         }
 
-        attachObject.transform.parent = rb ? rb.transform : null;
-        attachObject.transform.position = origin;
-        FMODUnity.RuntimeManager.DetachInstanceFromGameObject(instance);
-        FMODUnity.RuntimeManager.AttachInstanceToGameObject(instance, attachObject.transform, rb ? rb : null);
+        if (attachObject != null)
+        {
+            attachObject.transform.parent = rb ? rb.transform : null;
+            attachObject.transform.position = origin;
+            FMODUnity.RuntimeManager.DetachInstanceFromGameObject(instance);
+            FMODUnity.RuntimeManager.AttachInstanceToGameObject(instance, attachObject.transform, rb ? rb : null);
+        }
 
 
         if (parameters != null)

--- a/Assets/Scripts/Saving/SaveLoadManager.cs
+++ b/Assets/Scripts/Saving/SaveLoadManager.cs
@@ -42,6 +42,7 @@ public class SaveLoadManager : MonoBehaviour
     private void CollectInventoryData()
     {
         InventoryHolder[] inventoryHolders = FindObjectsOfType<InventoryHolder>();
+        newData = new SaveData();
         foreach (var holder in inventoryHolders)
         {
             string objectName = holder.gameObject.name;


### PR DESCRIPTION
- Ensured that old saved data was being cleared out properly and not persisting.
- Fixed a softlock that would occur on repeated loops due to trying to access a destroyed gameObject.